### PR TITLE
Only target direct children of the current row being parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function($) {
 
         $("tr", this).each(function(row_idx, row) {
             curr_y = 0;
-            $("td, th", row).each(function(col_idx, col) {
+            $("> td, > th", row).each(function(col_idx, col) {
                 var rowspan = $(col).attr('rowspan') || 1;
                 var colspan = $(col).attr('colspan') || 1;
                 if (textMode === true) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cheerio-tableparser",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "description": "The tables parser plugin for cheerio",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cheerio-tableparser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The tables parser plugin for cheerio",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
I ran into a table that had a table nested inside a table cell which confused the parser. This change did fix my issue, but I haven't tested it thoroughly, and think it could be considered a breaking change.